### PR TITLE
Remove x509 extensions from CSR config file

### DIFF
--- a/certs/cfg/braidnet.cfg
+++ b/certs/cfg/braidnet.cfg
@@ -15,8 +15,5 @@ commonName             = braidnet
 # organizationalUnitName =
 # emailAddress           =
 
+# extensions filled later
 [ v3_req ]
-subjectKeyIdentifier = hash
-keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment, keyAgreement
-extendedKeyUsage = critical, serverAuth
-# subjectAltName will be filled by the pre_start hook or module braidnet_cert


### PR DESCRIPTION
These will be added by Braidcert when creating the certificate.